### PR TITLE
[crt15] basic scrollstart offset

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -36,6 +36,8 @@ export const Carousel = (props, children) => {
             {
                 className: sliderCx,
                 dataset: {
+                    deadseaId: props.id,
+                    deadseaStartOffset: props.startOffset || 0,
                     deadseaOrientation: props.orientation,
                     deadseaChildQuery: props.childQuery || '',
                 },

--- a/src/declarations/types.d.ts
+++ b/src/declarations/types.d.ts
@@ -70,11 +70,12 @@ export interface SimpleCarouselProps extends BaseComponentProps {
 }
 
 export interface CarouselProps extends BaseComponentProps {
-    id: string;
-    title?: string;
-    orientation: Orientation;
-    childQuery?: string;
     blockExit?: string;
+    childQuery?: string;
+    id: string;
+    orientation: Orientation;
+    startOffset?: number;
+    title?: string;
 }
 
 export interface NavProps {


### PR DESCRIPTION
This PR:

- adds some basic scroll offset behaviour

For example

```javascript
Carousel({
  id: 'crt',
  orientation: 'horizontal',
  startOffset: 1
}, children)
```

In the above, the carousel would not start applying any `transformX` until focus had moved past index 0.
