### PR TITLE
[crt105] notifications followup

### DIFF
--- a/src/components/Keyboard.css
+++ b/src/components/Keyboard.css
@@ -14,6 +14,7 @@
     border: none;
     border-radius: 0.25rem;
     font-size: 1.5rem;
+    padding: 0;
 }
 
 .keyboardKey:global(.focused) {

--- a/src/components/TextInput.css
+++ b/src/components/TextInput.css
@@ -5,6 +5,7 @@
     margin-right: 1rem;
     outline: none;
     height: 2rem;
+    color: #fff;
 }
 
 .textInput input:global(.focused) {

--- a/src/config/qwertyKeyMap.js
+++ b/src/config/qwertyKeyMap.js
@@ -1,0 +1,176 @@
+export const keyMap = [
+    [
+        {
+            display: '1',
+            value: '1',
+        },
+        {
+            display: '2',
+            value: '2',
+        },
+        {
+            display: '3',
+            value: '3',
+        },
+        {
+            display: '4',
+            value: '4',
+        },
+        {
+            display: '5',
+            value: '5',
+        },
+        {
+            display: '6',
+            value: '6',
+        },
+        {
+            display: '7',
+            value: '7',
+        },
+        {
+            display: '8',
+            value: '8',
+        },
+        {
+            display: '9',
+            value: '9',
+        },
+        {
+            display: '0',
+            value: '0',
+        },
+    ],
+    [
+        {
+            display: 'Q',
+            value: 'q',
+        },
+        {
+            display: 'W',
+            value: 'w',
+        },
+        {
+            display: 'E',
+            value: 'e',
+        },
+        {
+            display: 'R',
+            value: 'r',
+        },
+        {
+            display: 'T',
+            value: 't',
+        },
+        {
+            display: 'Y',
+            value: 'y',
+        },
+        {
+            display: 'U',
+            value: 'u',
+        },
+        {
+            display: 'I',
+            value: 'i',
+        },
+        {
+            display: 'O',
+            value: 'o',
+        },
+        {
+            display: 'P',
+            value: 'p',
+        },
+    ],
+    [
+        {
+            display: 'A',
+            value: 'a',
+        },
+        {
+            display: 'S',
+            value: 's',
+        },
+        {
+            display: 'D',
+            value: 'd',
+        },
+        {
+            display: 'F',
+            value: 'f',
+        },
+        {
+            display: 'G',
+            value: 'g',
+        },
+        {
+            display: 'H',
+            value: 'h',
+        },
+        {
+            display: 'J',
+            value: 'j',
+        },
+        {
+            display: 'K',
+            value: 'k',
+        },
+        {
+            display: 'L',
+            value: 'l',
+        },
+    ],
+    [
+        {
+            display: 'Z',
+            value: 'z',
+        },
+        {
+            display: 'X',
+            value: 'x',
+        },
+        {
+            display: 'C',
+            value: 'c',
+        },
+        {
+            display: 'V',
+            value: 'v',
+        },
+        {
+            display: 'B',
+            value: 'b',
+        },
+        {
+            display: 'N',
+            value: 'n',
+        },
+        {
+            display: 'M',
+            value: 'm',
+        },
+    ],
+    [
+        {
+            display: 'ENTER',
+            value: 'ENTER',
+            width: 2,
+        },
+        {
+            display: 'DEL',
+            value: 'DEL',
+            width: 2,
+        },
+        {
+            display: '_',
+            value: 'SPACE',
+            width: 2,
+        },
+        {
+            display: 'EXIT',
+            value: 'EXIT',
+            width: 2,
+        },
+    ],
+];

--- a/src/libs/deadSea.js
+++ b/src/libs/deadSea.js
@@ -1,7 +1,7 @@
 import { Orientation } from '../enums/Orientation';
 
 import { collectionToArray } from '../utils/dom/collectionToArray';
-import { getDataFromEl } from '../utils/dom/getDataFromEl';
+import { $dataGet } from '../utils/dom/$dataGet';
 
 /** @type { {[index: string]: number[]} } */
 const offsetCache = {};
@@ -69,11 +69,11 @@ function doTheHardWork(scrollEl, useTransforms) {
     // todo: either tell the type system to always expect an id, or generate one for it.
     const focusedEl = document.querySelector(focusedQuery);
 
-    const scrollId = getDataFromEl(scrollEl, 'deadseaId') || '';
-    const orientation = getDataFromEl(scrollEl, 'deadseaOrientation');
-    const qs = getDataFromEl(scrollEl, 'deadseaChildQuery') || '';
-    const startOffset = getDataFromEl(scrollEl, 'deadseaStartOffset') || 0;
-    const startQs = getDataFromEl(scrollEl, 'deadseaScrollStartQuery') || '';
+    const scrollId = $dataGet(scrollEl, 'deadseaId') || '';
+    const orientation = $dataGet(scrollEl, 'deadseaOrientation');
+    const qs = $dataGet(scrollEl, 'deadseaChildQuery') || '';
+    const startOffset = $dataGet(scrollEl, 'deadseaStartOffset') || 0;
+    const startQs = $dataGet(scrollEl, 'deadseaScrollStartQuery') || '';
     const offsetProp =
         orientation === Orientation.HORIZONTAL ? 'offsetLeft' : 'offsetTop';
     const scrollables =

--- a/src/libs/makeElement.js
+++ b/src/libs/makeElement.js
@@ -177,6 +177,9 @@ export const legend = (...args) =>
 export const input = (...args) =>
     makeElement('input', args[0], ...args.slice(1));
 
+/** @type {ShorthandMakeElement}  */
+export const pre = (...args) => makeElement('pre', args[0], ...args.slice(1));
+
 // function input() {
 //     const args = collectionToArray(arguments);
 //     const propsOrChild = args[0];

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -1,7 +1,7 @@
 import { getNextFocus } from '@bbc/tv-lrud-spatial';
 
 import { scrollAction } from './libs/deadSea';
-import { getDataFromEl } from './utils/dom/getDataFromEl';
+import { $dataGet } from './utils/dom/$dataGet';
 import { assertKey } from './utils/keys';
 import { AdditionalKeys } from './enums/AdditionalKeys';
 import { Direction } from './enums/Direction';
@@ -268,7 +268,7 @@ function handleEnter(event) {
         event.target instanceof HTMLAnchorElement &&
         event.target.nodeName === 'A'
     ) {
-        if (getDataFromEl(event.target, 'external')) {
+        if ($dataGet(event.target, 'external')) {
             // it is an external link
             return handleExternal(event.target.href);
         }

--- a/src/utils/dom/$dataGet.js
+++ b/src/utils/dom/$dataGet.js
@@ -4,7 +4,7 @@
  * @param {string} dataProp
  * @returns {*}
  */
-export function getDataFromEl(el, dataProp) {
+export function $dataGet(el, dataProp) {
     const value = el.dataset && el.dataset[dataProp];
 
     if (typeof value === 'string') {

--- a/src/utils/dom/$dataGet.test.js
+++ b/src/utils/dom/$dataGet.test.js
@@ -3,14 +3,14 @@
  */
 
 import { describe, expect, test } from 'vitest';
-import { getDataFromEl } from './getDataFromEl';
+import { $dataGet } from './$dataGet';
 
-describe('getDataFromEl', () => {
+describe('$dataGet', () => {
     test('it will return boolean value of data-prop from HTMLElement', () => {
         const mockEl = document.createElement('div');
         mockEl.dataset.boolean = 'true';
 
-        const assert = getDataFromEl(mockEl, 'boolean');
+        const assert = $dataGet(mockEl, 'boolean');
 
         expect(assert).toEqual(true);
     });
@@ -19,7 +19,7 @@ describe('getDataFromEl', () => {
         const mockEl = document.createElement('div');
         mockEl.dataset.complex = '{"x": 1, "y": true, "z": "test"}';
 
-        const assert = getDataFromEl(mockEl, 'complex');
+        const assert = $dataGet(mockEl, 'complex');
 
         expect(assert).toEqual({
             x: 1,
@@ -32,7 +32,7 @@ describe('getDataFromEl', () => {
         const mockEl = document.createElement('div');
         mockEl.dataset.number = '1';
 
-        const assert = getDataFromEl(mockEl, 'number');
+        const assert = $dataGet(mockEl, 'number');
 
         expect(assert).toEqual(1);
     });
@@ -41,7 +41,7 @@ describe('getDataFromEl', () => {
         const mockEl = document.createElement('div');
         mockEl.dataset.number = '1';
 
-        const assert = getDataFromEl(mockEl, 'noprop');
+        const assert = $dataGet(mockEl, 'noprop');
 
         expect(assert).toBe('');
     });

--- a/src/utils/dom/$dataSet.js
+++ b/src/utils/dom/$dataSet.js
@@ -1,0 +1,22 @@
+/**
+ *
+ * @param {HTMLElement} el
+ * @param {string} dataProp
+ * @param {string|boolean|number|object} value
+ */
+export function $dataSet(el, dataProp, value) {
+    if (!el || !dataProp || value === undefined || value === null) {
+        // return an error?
+        return '';
+    }
+    // probably only need to call JSON.stringify
+    // if the value is complex
+    const type = typeof value;
+
+    if (type === "string") {
+        el.dataset[dataProp] = value + "";
+    } else {
+        el.dataset[dataProp] = JSON.stringify(value);
+    }
+
+}

--- a/src/utils/dom/$dataSet.test.js
+++ b/src/utils/dom/$dataSet.test.js
@@ -1,0 +1,48 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, test } from 'vitest';
+import { $dataSet } from './$dataSet';
+
+describe('$dataSet', () => {
+  test('it sets a string', () => {
+    const mockEl = document.createElement('div');
+    const mockDataValue = 'xyz';
+
+    $dataSet(mockEl, 'testString', mockDataValue);
+    
+    const assert = mockEl.dataset.testString
+    expect(assert).toEqual(mockDataValue);
+  });
+
+  test('it sets a bool', () => {
+    const mockEl = document.createElement('div');
+    const mockDataValue = true;
+
+    $dataSet(mockEl, 'testBool', mockDataValue);
+    
+    const assert = mockEl.dataset.testBool
+    expect(assert).toEqual(mockDataValue + "");
+  });
+
+  test('it sets a number', () => {
+    const mockEl = document.createElement('div');
+    const mockDataValue = 123;
+
+    $dataSet(mockEl, 'testNumber', mockDataValue);
+    
+    const assert = mockEl.dataset.testNumber
+    expect(assert).toEqual(mockDataValue + "");
+  });
+
+  test('it sets an object', () => {
+    const mockEl = document.createElement('div');
+    const mockDataValue = { x: 1, y: 2, z: false };
+
+    $dataSet(mockEl, 'testObj', mockDataValue);
+    
+    const assert = mockEl.dataset.testObj
+    expect(assert).toEqual(JSON.stringify(mockDataValue));
+  });
+});

--- a/src/utils/dom/handleKeydownOnElement.js
+++ b/src/utils/dom/handleKeydownOnElement.js
@@ -11,13 +11,19 @@ import { assertKey } from '../keys';
  * @param {string[]} [allowedKeys]
  */
 export function handleKeydownOnElement(el, callback, allowedKeys) {
-    el.addEventListener('keydown', (e) => {
+    /**
+     * @name func
+     * @param {KeyboardEvent} e 
+     */
+    function func(e) {
         if ((allowedKeys && assertKey(e, allowedKeys)) || !allowedKeys) {
             callback(e);
         }
-    });
+    }
 
-    return function () {
-        el.removeEventListener('keydown', (e) => callback(e));
+    el.addEventListener('keydown', func);
+
+    return () => {
+        el.removeEventListener('keydown', func);
     };
 }

--- a/src/views/formExample.css
+++ b/src/views/formExample.css
@@ -15,3 +15,24 @@
 .myForm > div {
     margin-bottom: 1rem;
 }
+
+.keyboardDrawer {
+    position: absolute;
+    transition: transform 250ms ease;
+    transform: translateY(200%);
+    width: 100%;
+    background: rgba(0, 0, 0, 0.7);
+}
+
+.keyboardDrawer:global(.active) {
+    transform: translateY(0%);
+}
+
+.output {
+    position: absolute;
+    right: 0;
+    top: 0;
+    left: auto;
+    background: #363636;
+    color: white;
+}

--- a/src/views/formExample.js
+++ b/src/views/formExample.js
@@ -4,19 +4,50 @@
 
 import { AdditionalKeys } from '../enums/AdditionalKeys';
 
+import { keyMap } from '../config/qwertyKeyMap';
+
 import { BaseView } from '../libs/baseView';
-import { div, form } from '../libs/makeElement';
+import { div, form, pre } from '../libs/makeElement';
 import { NotificationsService } from '../libs/notifications';
 
 import { handleKeydownOnElement } from '../utils/dom/handleKeydownOnElement';
 import { assertKey } from '../utils/keys';
+import { cx } from '../utils/dom/cx';
+import { $dataGet } from '../utils/dom/$dataGet';
+import { createReactive } from '../utils/object/createReactive';
 
 import { Notification } from '../components/Notification';
-
-import s from './formExample.css';
-import { cx } from '../utils/dom/cx';
 import { Checkbox } from '../components/Checkbox';
 import { TextInput } from '../components/TextInput';
+import { Keyboard } from '../components/Keyboard';
+
+import { focusInto, moveFocus, setLrudScope } from '../navigation';
+
+import s from './formExample.css';
+import { $dataSet } from '../utils/dom/$dataSet';
+
+/**
+ * @type {HTMLFormElement}
+ */
+const MyForm = form(
+    { className: s.myForm },
+    TextInput({
+        id: 'firstName',
+        label: 'First name',
+    }),
+    TextInput({
+        id: 'surname',
+        label: 'Surname',
+    }),
+    Checkbox({
+        id: 'likescakes',
+        label: 'Likes cakes?',
+    }),
+    Checkbox({
+        id: 'playagame',
+        label: 'Global Thermonuclear War?',
+    })
+);
 
 /**
  * @extends BaseView
@@ -28,36 +59,140 @@ export class FormExample extends BaseView {
     constructor(options) {
         super(options);
 
-        this.formEl = form(
-            { className: s.myForm },
-            TextInput({
-                id: 'firstName',
-                label: 'First name',
-            }),
-            TextInput({
-                id: 'surname',
-                label: 'Surname',
-            }),
-            Checkbox({
-                id: 'likescakes',
-                label: 'Likes cakes?',
-            }),
-            Checkbox({
-                id: 'playagame',
-                label: 'Global Thermonuclear War?',
-            })
+        /** @type {HTMLInputElement=} */
+        this.activeInput = undefined;
+
+        this.keyboard = div(
+            {
+                className: s.keyboardDrawer,
+            },
+            Keyboard({ keyMap: keyMap })
         );
+
+        const initialFormState = {
+            firstName: '',
+            surname: '',
+            likescakes: false,
+            playagame: false,
+        };
+
+        /** @type {Record<string, any>} */
+        this.formState = createReactive(
+            initialFormState,
+            this.updateFormOutput.bind(this)
+        );
+
+        this.formOutput = pre(
+            { className: s.output },
+            JSON.stringify(initialFormState, null, 4)
+        );
+
+        /**
+         * @type {HTMLFormElement}
+         */
+        this.formEl = MyForm;
     }
 
     destructor() {
-        this.keyHandleCleanup && this.keyHandleCleanup();
+        this.keydownHandleCleanup && this.keydownHandleCleanup();
     }
 
     viewDidLoad() {
-        this.keyHandleCleanup = handleKeydownOnElement(
+        this.keydownHandleCleanup = handleKeydownOnElement(
             this.formEl,
             this.handleForm.bind(this)
         );
+    }
+
+    /**
+     * @name updateFormOutput
+     * @param {*} state
+     */
+    updateFormOutput(state) {
+        // update the debug output
+        this.formOutput.innerHTML = JSON.stringify(state, null, 4);
+
+        // get the formInputs
+        const formInputEls = this.formEl.elements;
+
+        for (const key in state) {
+            if (Object.prototype.hasOwnProperty.call(state, key)) {
+                const formEl = formInputEls.namedItem(key);
+                if (formEl && formEl instanceof HTMLInputElement) {
+                    if (formEl.type === 'checkbox') {
+                        const method = state[key]
+                            ? 'setAttribute'
+                            : 'removeAttribute';
+
+                        formEl[method]('checked', '');
+                    }
+
+                    if (formEl.type === 'text') {
+                        formEl.value = state[key];
+                    }
+                }
+            }
+        }
+    }
+
+    listenToKeyboard() {
+        this.keyboardHandleCleanup = handleKeydownOnElement(
+            this.keyboard,
+            this.handleKeyboard.bind(this)
+        );
+    }
+
+    closeKeyboard() {
+        // hide the keyboard
+        this.keyboard.classList.remove('active');
+
+        // stop listening to keyboard
+        if (this.keyboardHandleCleanup) this.keyboardHandleCleanup();
+
+        // restore focus to the element we were on before
+        // whizzing the keyboard into view
+        this.activeInput && moveFocus(this.activeInput);
+
+        // restore the scope, undefined is "default"
+        setLrudScope();
+    }
+
+    /**
+     * @param {KeyboardEvent} event
+     */
+    handleKeyboard(event) {
+        if (
+            event.target instanceof HTMLElement &&
+            assertKey(event, AdditionalKeys.ENTER)
+        ) {
+            const keyPressValue = $dataGet(event.target, 'keyValue');
+            const inputName = this.activeInput && this.activeInput.name;
+
+            switch (keyPressValue) {
+                case 'EXIT':
+                    if (inputName) {
+                        const prevValue = this.activeInput && $dataGet(this.activeInput, 'prevValue')
+                        this.formState[inputName] = prevValue || '';
+                    }
+                    this.closeKeyboard();
+                    break;
+                case 'ENTER':
+                    // set the new prevValue on the input
+                    inputName && this.activeInput && $dataSet(this.activeInput, 'prevValue', this.formState[inputName])
+                    this.closeKeyboard();
+                    break;
+                case 'DEL':
+                    if (inputName) {
+                        this.formState[inputName] = this.formState[
+                            inputName
+                        ].slice(0, this.formState[inputName].length - 1);
+                    }
+                    break;
+                default:
+                    if (inputName) this.formState[inputName] += keyPressValue;
+                    break;
+            }
+        }
     }
 
     /**
@@ -65,17 +200,43 @@ export class FormExample extends BaseView {
      */
     handleForm(event) {
         if (assertKey(event, AdditionalKeys.ENTER)) {
+            if (
+                event.target instanceof HTMLInputElement &&
+                event.target.type === 'text'
+            ) {
+                this.activeInput = event.target;
+                // store the current value, in case we cancel
+                // and need to restore
+                $dataSet(
+                    this.activeInput, 
+                    'prevValue', 
+                    this.formState[this.activeInput.name]
+                )
+
+                // show the keyboard
+                this.keyboard.classList.add('active');
+
+                // focus on it
+                focusInto(this.keyboard);
+
+                // limit the scope
+                setLrudScope(this.keyboard);
+
+                // listen for events on it
+                this.listenToKeyboard();
+            }
+
             if (event.target instanceof HTMLLabelElement) {
-                console.log(`[this.id][handleForm] `, event);
-                const input = document.getElementsByName(
-                    event.target.htmlFor
-                )[0];
+                const name = event.target.htmlFor;
+                const qs = `[name="${name}"]`;
+                const input = document.querySelector(qs);
 
                 if (input instanceof HTMLInputElement) {
-                    const method = input.checked
-                        ? 'removeAttribute'
-                        : 'setAttribute';
-                    input[method]('checked', '');
+                    this.formState[name] = !input.checked;
+                    // const method = input.checked
+                    //     ? 'removeAttribute'
+                    //     : 'setAttribute';
+                    // input[method]('checked', '');
 
                     NotificationsService.sendNotification(
                         Notification({
@@ -91,6 +252,14 @@ export class FormExample extends BaseView {
     render() {
         const cxView = cx('view', s.view);
 
-        return div({ className: cxView, id: this.id }, this.formEl);
+        return div(
+            {
+                className: cxView,
+                id: this.id,
+            },
+            this.formOutput,
+            this.formEl,
+            this.keyboard
+        );
     }
 }

--- a/src/views/home.js
+++ b/src/views/home.js
@@ -10,7 +10,7 @@ import { pageData } from '../stubData/pageData';
 
 import { handleKeydownOnElement } from '../utils/dom/handleKeydownOnElement';
 import { assertKey } from '../utils/keys';
-import { getDataFromEl } from '../utils/dom/getDataFromEl';
+import { $dataGet } from '../utils/dom/$dataGet';
 
 import { Carousel } from '../components/Carousel';
 import { Tile } from '../components/Tile';
@@ -32,7 +32,7 @@ function findNextBackStop(el) {
         return;
     }
 
-    if (getDataFromEl(el, 'backStop')) {
+    if ($dataGet(el, 'backStop')) {
         const firstChild = el.children[0];
         if (
             firstChild.classList.contains('focused') ||

--- a/src/views/search.js
+++ b/src/views/search.js
@@ -9,7 +9,7 @@ import { keyMap } from '../config/keyMap';
 
 import { searchData } from '../stubData/searchData';
 
-import { getDataFromEl } from '../utils/dom/getDataFromEl';
+import { $dataGet } from '../utils/dom/$dataGet';
 import { assertKey } from '../utils/keys';
 import { handleKeydownOnElement } from '../utils/dom/handleKeydownOnElement';
 
@@ -66,7 +66,7 @@ export class Search extends BaseView {
             event.target instanceof HTMLElement &&
             assertKey(event, AdditionalKeys.ENTER)
         ) {
-            const keyPressValue = getDataFromEl(event.target, 'keyValue');
+            const keyPressValue = $dataGet(event.target, 'keyValue');
 
             if (typeof keyPressValue === 'string') {
                 this.updateSearchInput(keyPressValue);


### PR DESCRIPTION
This PR:

- finishes off the form. 
- virtual keyboard now has a custom layout
- it's a demo, POC. 

If forms develops more needs, then the logic in the view could probably be spun out some more as the patterns emerge. Certainly, modifying values on inputs could be a series of helpers, (`appendInputValue(input, string)`). Also, looking at the form itself, simple as it is, it could be spun out to an adjacent file and then imported - it's just HTML, it doesn't need to live in the ctor.

The idea of forms on TVs is kind of horrifying, but they would be useful for settings screens. However, if you're asking users to fill in forms on TVs I think you should go back to your designs.