### PR TITLE
`[crt217]` abstract over `event.target` use

### DIFF
--- a/src/utils/dom/normaliseEventTarget.js
+++ b/src/utils/dom/normaliseEventTarget.js
@@ -1,0 +1,8 @@
+/**
+ * 
+ * @param {KeyboardEvent} event 
+ * @returns 
+ */
+export function normaliseEventTarget(event) {
+  return event.target && event.target !== window ? event.target : document.activeElement;
+}

--- a/src/utils/registerPopup.js
+++ b/src/utils/registerPopup.js
@@ -1,6 +1,7 @@
 import { AdditionalKeys } from '../models/AdditionalKeys';
 import { focusInto, setLrudScope } from '../navigation';
 import { handleKeydownOnElement } from './dom/handleKeydownOnElement';
+import { normaliseEventTarget } from './dom/normaliseEventTarget';
 
 /**
  * @name registerPopup
@@ -12,8 +13,10 @@ import { handleKeydownOnElement } from './dom/handleKeydownOnElement';
 export function registerPopup(popupEl, handler, outlet) {
     /** @type { (event: KeyboardEvent) => void }  */
     const popupCallback = (event) => {
-        if (event.target instanceof HTMLElement) {
-            handler(event.target.id);
+        const elTarget = normaliseEventTarget(event);
+        
+        if (elTarget instanceof HTMLElement) {
+            handler(elTarget.id);
         }
     };
 

--- a/src/views/formExample.js
+++ b/src/views/formExample.js
@@ -25,6 +25,7 @@ import { focusInto, moveFocus, setLrudScope } from '../navigation';
 
 import s from './formExample.scss';
 import { $dataSet } from '../utils/dom/$dataSet';
+import { normaliseEventTarget } from '../utils/dom/normaliseEventTarget';
 
 /**
  * @type {HTMLFormElement}
@@ -161,11 +162,12 @@ export class FormExample extends BaseView {
      * @param {KeyboardEvent} event
      */
     handleKeyboard(event) {
+        const elTarget = normaliseEventTarget(event);
         if (
-            event.target instanceof HTMLElement &&
+            elTarget instanceof HTMLElement &&
             assertKey(event, AdditionalKeys.ENTER)
         ) {
-            const keyPressValue = $dataGet(event.target, 'keyValue');
+            const keyPressValue = $dataGet(elTarget, 'keyValue');
             const inputName = this.activeInput && this.activeInput.name;
 
             switch (keyPressValue) {
@@ -207,12 +209,14 @@ export class FormExample extends BaseView {
      * @param {KeyboardEvent} event
      */
     handleForm(event) {
+        const elTarget = normaliseEventTarget(event);
+
         if (assertKey(event, AdditionalKeys.ENTER)) {
             if (
-                event.target instanceof HTMLInputElement &&
-                event.target.type === 'text'
+                elTarget instanceof HTMLInputElement &&
+                elTarget.type === 'text'
             ) {
-                this.activeInput = event.target;
+                this.activeInput = elTarget;
                 // store the current value, in case we cancel
                 // and need to restore
                 $dataSet(
@@ -234,8 +238,8 @@ export class FormExample extends BaseView {
                 this.listenToKeyboard();
             }
 
-            if (event.target instanceof HTMLLabelElement) {
-                const name = event.target.htmlFor;
+            if (elTarget instanceof HTMLLabelElement) {
+                const name = elTarget.htmlFor;
                 const qs = `[name="${name}"]`;
                 const input = document.querySelector(qs);
 

--- a/src/views/home.js
+++ b/src/views/home.js
@@ -21,6 +21,7 @@ import { AdditionalKeys } from '../models/AdditionalKeys';
 
 import { focusInto } from '../navigation';
 import { appOutlets } from '../outlets';
+import { normaliseEventTarget } from '../utils/dom/normaliseEventTarget';
 
 /**
  *
@@ -77,10 +78,10 @@ export class Home extends BaseView {
      */
     handleBack(event) {
         if (assertKey(event, AdditionalKeys.BACKSPACE)) {
-            const target = event.target;
+            const elTarget = normaliseEventTarget(event);
 
-            if (target instanceof HTMLElement) {
-                const nextBack = findNextBackStop(target);
+            if (elTarget instanceof HTMLElement) {
+                const nextBack = findNextBackStop(elTarget);
 
                 if (nextBack) {
                     focusInto(nextBack);
@@ -107,11 +108,12 @@ export class Home extends BaseView {
      * @param {KeyboardEvent} event
      */
     handleKeyboard(event) {
+        const elTarget  = normaliseEventTarget(event);
         if (
-            event.target instanceof HTMLAnchorElement &&
+            elTarget instanceof HTMLAnchorElement &&
             assertKey(event, AdditionalKeys.ENTER)
         ) {
-            const keyPressValue = event.target.href;
+            const keyPressValue = elTarget.href;
             window.location.href = keyPressValue;
         }
     }

--- a/src/views/search.js
+++ b/src/views/search.js
@@ -20,6 +20,7 @@ import { Keyboard } from '../components/Keyboard';
 import { Carousel } from '../components/Carousel';
 
 import s from './search.scss';
+import { normaliseEventTarget } from '../utils/dom/normaliseEventTarget';
 /**
  * @extends BaseView
  */
@@ -62,11 +63,12 @@ export class Search extends BaseView {
      * @param {KeyboardEvent} event
      */
     handleKeyboard(event) {
+        const elTarget = normaliseEventTarget(event);
         if (
-            event.target instanceof HTMLElement &&
+            elTarget instanceof HTMLElement &&
             assertKey(event, AdditionalKeys.ENTER)
         ) {
-            const keyPressValue = $dataGet(event.target, 'keyValue');
+            const keyPressValue = $dataGet(elTarget, 'keyValue');
 
             if (typeof keyPressValue === 'string') {
                 this.updateSearchInput(keyPressValue);

--- a/src/views/show.js
+++ b/src/views/show.js
@@ -23,6 +23,7 @@ import Logo from '../assets/Public_Domain_Mark_button.svg.png';
 
 import s from './show.scss';
 import { Heading } from '../components/Heading';
+import { normaliseEventTarget } from '../utils/dom/normaliseEventTarget';
 
 /**
  * @extends BaseView
@@ -90,10 +91,11 @@ export class Show extends BaseView {
      * @param {KeyboardEvent} event
      */
     customHandleKeyDown(event) {
+        const elTarget = normaliseEventTarget(event);
         const navEl =
-            event.target &&
-            event.target instanceof HTMLElement &&
-            event.target.id.match(/nav/);
+            elTarget &&
+            elTarget instanceof HTMLElement &&
+            elTarget.id.match(/nav/);
         const isUpOrDown = assertKey(event, [Direction.UP, Direction.DOWN]);
 
         if (isUpOrDown && this.scope && !navEl) {


### PR DESCRIPTION
This PR:

- abstracts over `event.target` and falls back to `document.activeElement`. This might change to avoid `event.target` in the future but I would like to test this some more first.