### PR TITLE
`[crt/317]` update `data-focus` when calling `focusInto`

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -14,6 +14,7 @@ import { Direction } from './models/Direction';
 import { animations } from './config/animations';
 
 import { PubSub } from './state/PubSub';
+import { $dataSet } from './utils/dom/$dataSet';
 
 /** @type {HTMLElement|undefined} */
 let _scope = undefined;
@@ -75,10 +76,10 @@ export function handleKeyDown(event, scope) {
         return handleEnter(event);
     }
 
-    if (assertKey(event, AdditionalKeys.BACKSPACE)) {
-        // early return on `back` keypress.
-        return handleBack(event);
-    }
+    // if (assertKey(event, AdditionalKeys.BACKSPACE)) {
+    //     // early return on `back` keypress.
+    //     return handleBack(event);
+    // }
 
     if (
         assertKey(event, [
@@ -225,7 +226,7 @@ const focusWithoutScrolling = function (el) {
  * @param {HTMLElement} target
  * @returns {HTMLElement[]}
  */
-function getElementContainer(target) {
+export function getElementContainer(target) {
     let a = target;
     const els = [];
 
@@ -253,13 +254,13 @@ function handleOtherKey(event) {
     event.preventDefault();
 }
 
-/**
- * handleBack
- * @param {KeyboardEvent} event
- */
-function handleBack(event) {
-    event.preventDefault();
-}
+// /**
+//  * handleBack
+//  * @param {KeyboardEvent} event
+//  */
+// function handleBack(event) {
+//     event.preventDefault();
+// }
 
 /**
  * handleEnter
@@ -304,8 +305,8 @@ export function initNavigation() {
     // todo: probably need a pause/resume spatial navigation method so
     // you can toggle between pointer and spatial based modalities
     window.addEventListener('click', handleClick);
+    console.log('[initNavigation] adding keydown listener');
     window.addEventListener('keydown', (...args) => {
-        console.log('[keydown] ', ...args);
         throttle(_handleKeyDown, 60, args)
     });
 
@@ -342,6 +343,16 @@ export function focusInto(scopeEl) {
         const nextFocus = getNextFocus(undefined, undefined, scopeEl);
 
         if (nextFocus) {
+
+            if (nextFocus.id) {
+                const containers = getElementContainer(nextFocus);
+                const container = containers[0];
+    
+                if ($dataGet(container, 'focus')) {
+                    $dataSet(container, 'focus', nextFocus.id);
+                }
+            }
+
             moveFocus(nextFocus);
             lastFocus = nextFocus;
         }

--- a/src/stubData/pageData.js
+++ b/src/stubData/pageData.js
@@ -10,9 +10,9 @@ export const pageData = {
     items: ['YouView', 'Freeview QA', 'Sky Glass Preprod', 'Freesat DEV'].map(
         (env) => ({
             title: env,
-            id: env.toLowerCase().replace(' ', ''),
+            id: env.toLowerCase().replace(/ /g, ''),
             items: ['0A', '0B', '0C', '0D', '0E', '0F'].map((inst) => ({
-                id: [env.toLowerCase().replace(' ', ''), inst].join('-'),
+                id: [env.toLowerCase().replace(/ /g, ''), inst].join('-'),
                 title: [env, inst].join(' '),
                 url: `https://www.google.com/search?q=${encodeURI(env)}`,
             })),

--- a/src/views/home.js
+++ b/src/views/home.js
@@ -19,10 +19,9 @@ import { Spinner } from '../components/Spinner';
 import { Orientation } from '../models/Orientation';
 import { AdditionalKeys } from '../models/AdditionalKeys';
 
-import { focusInto, getElementContainer, getLastFocus } from '../navigation';
+import { focusInto } from '../navigation';
 import { appOutlets } from '../outlets';
 import { normaliseEventTarget } from '../utils/dom/normaliseEventTarget';
-import { $dataSet } from '../utils/dom/$dataSet';
 
 /**
  *
@@ -113,19 +112,7 @@ export class Home extends BaseView {
                     // focus into the menu
                     const navEl = appOutlets['nav'];
                     focusInto(navEl);
-                }
-
-                const currentFocus = getLastFocus()
-
-                if (currentFocus && currentFocus.id) {
-                    const containers = getElementContainer(currentFocus.el);
-                    const container = containers[0];
-        
-                    if ($dataGet(container, 'focus')) {
-                        $dataSet(container, 'focus', currentFocus.id);
-                    }
-                }
- 
+                } 
             }
         }
     }


### PR DESCRIPTION
This PR:

- fixes `id` generation in stubData
- adjust listeners in `/`
- update container `data-focus` if back-stop has `id`